### PR TITLE
Improve consistency of formatting for list

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -32,10 +32,10 @@
 
 ;; Clerk is a notebook library for Clojure that aims to address these problems by doing less, namely:
 
-;; * no editing environment, folks can keep using the editors they know and love
-;; * no new format: Clerk notebooks are regular Clojure namespaces (interspersed with markdown comments). This also means Clerk notebooks are meant to be stored in source control.
-;; * no out-of-order execution: Clerk notebooks always evaluate from top to bottom. Clerk builds a dependency graph of Clojure vars and only recomputes the needed changes to keep the feedback loop fast.
-;; * no external process: Clerk runs inside your Clojure process, giving Clerk access to all code on the classpath.
+;; * No editing environment: Folks can keep using the editors they know and love
+;; * No new format: Clerk notebooks are regular Clojure namespaces (interspersed with markdown comments). This also means Clerk notebooks are meant to be stored in source control.
+;; * No out-of-order execution: Clerk notebooks always evaluate from top to bottom. Clerk builds a dependency graph of Clojure vars and only recomputes the needed changes to keep the feedback loop fast.
+;; * No external process: Clerk runs inside your Clojure process, giving Clerk access to all code on the classpath.
 
 ;; ## 🚀 Getting Started
 


### PR DESCRIPTION
Just noticed that this was the only unordered list without leading entry capitalization. Additionally, I made the first entry use the same colon to delimit the problem and the exposition.