### PR TITLE
Vega-Lite: link to EDN examples

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -238,6 +238,10 @@
            :embed/opts {:actions false}})
 
 ;; You can provide a map of [embed options](https://github.com/vega/vega-embed#embed) to the vega viewer via the `:embed/opts` key.
+;;
+;; Clerk handles conversion from EDN to JSON for you.
+;; The official Vega-Lite examples are in JSON, but a Clojure/EDN version available:
+;; [Carsten Behring's Vega gallery in EDN](https://github.clerk.garden/behrica/vl-galery/).
 
 ;; ### 🎼 Code
 


### PR DESCRIPTION
As [discussed on Slack][slack], here's a PR to link to Carsten Behring's Vega gallery in EDN

[slack]: https://clojurians.slack.com/archives/C035GRLJEP8/p1671544872893189

Feel free to rewrite it however you want! I just want the link in, and English is not my native language.